### PR TITLE
Create .bettercodehub.yml

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,3 @@
+component_depth: 1
+languages:
+- java


### PR DESCRIPTION
bypassing the default yml files that contains : default excludes = true.
the code in this repo is located in the /example/ directory which normally is excluded from analysis